### PR TITLE
Add report import functionality to FHome form

### DIFF
--- a/Mira.Core/Class1.cs
+++ b/Mira.Core/Class1.cs
@@ -1,5 +1,0 @@
-﻿namespace Mira.Core;
-
-public class Class1
-{
-}

--- a/Mira.Core/Constants.cs
+++ b/Mira.Core/Constants.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mira.Core
+{
+    public abstract class Paths
+    {
+        public static string DataDirectory = Path.Combine(Environment.CurrentDirectory,"Data");
+        public static string ReportsDirectory = Path.Combine(DataDirectory, "Reports");
+    }
+
+    internal class Constants
+    {
+    }
+}

--- a/Mira.Core/Enums.cs
+++ b/Mira.Core/Enums.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mira.Core
+{
+    public class Enums
+    {
+        public enum ReportType
+        {
+            Client,
+            EMP
+        };
+    }
+}

--- a/Mira.UI/FHome.Designer.cs
+++ b/Mira.UI/FHome.Designer.cs
@@ -46,6 +46,7 @@ partial class FHome
         exportWordFormatToolStripMenuItem = new ToolStripMenuItem();
         exportCsvFormatToolStripMenuItem = new ToolStripMenuItem();
         generalInfoGroupBox = new GroupBox();
+        compareButton = new Button();
         comparisonDateTextBox = new TextBox();
         comparisonDateLabel = new Label();
         responsiblePersonTextBox = new TextBox();
@@ -57,20 +58,19 @@ partial class FHome
         projectNameTextBox = new TextBox();
         projectNameLabel = new Label();
         comparisonContainerGroupBox = new GroupBox();
-        compareButton = new Button();
+        comparisonResultsGroupBox = new GroupBox();
+        comparisonDataGridView = new DataGridView();
         planStatusGroupBox = new GroupBox();
-        clientPlanStatusValueLabel = new Label();
-        clientPlanStatusLabel = new Label();
         empPlanStatusValueLabel = new Label();
         empPlanStatusLabel = new Label();
-        comparisonDataGridView = new DataGridView();
-        comparisonResultsGroupBox = new GroupBox();
+        clientPlanStatusValueLabel = new Label();
+        clientPlanStatusLabel = new Label();
         mainMenuStrip.SuspendLayout();
         generalInfoGroupBox.SuspendLayout();
         comparisonContainerGroupBox.SuspendLayout();
-        planStatusGroupBox.SuspendLayout();
-        ((System.ComponentModel.ISupportInitialize)comparisonDataGridView).BeginInit();
         comparisonResultsGroupBox.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)comparisonDataGridView).BeginInit();
+        planStatusGroupBox.SuspendLayout();
         SuspendLayout();
         // 
         // mainMenuStrip
@@ -144,12 +144,14 @@ partial class FHome
         importClientPlanToolStripMenuItem.Name = "importClientPlanToolStripMenuItem";
         importClientPlanToolStripMenuItem.Size = new Size(131, 22);
         importClientPlanToolStripMenuItem.Text = "Plan Client";
+        importClientPlanToolStripMenuItem.Click += importClientPlanToolStripMenuItem_Click;
         // 
         // importEmpPlanToolStripMenuItem
         // 
         importEmpPlanToolStripMenuItem.Name = "importEmpPlanToolStripMenuItem";
         importEmpPlanToolStripMenuItem.Size = new Size(131, 22);
         importEmpPlanToolStripMenuItem.Text = "Plan EMP";
+        importEmpPlanToolStripMenuItem.Click += importEmpPlanToolStripMenuItem_Click;
         // 
         // exportToolStripMenuItem
         // 
@@ -196,6 +198,15 @@ partial class FHome
         generalInfoGroupBox.TabIndex = 1;
         generalInfoGroupBox.TabStop = false;
         generalInfoGroupBox.Text = "Information General";
+        // 
+        // compareButton
+        // 
+        compareButton.Location = new Point(616, 62);
+        compareButton.Name = "compareButton";
+        compareButton.Size = new Size(142, 23);
+        compareButton.TabIndex = 2;
+        compareButton.Text = "Comparer";
+        compareButton.UseVisualStyleBackColor = true;
         // 
         // comparisonDateTextBox
         // 
@@ -304,14 +315,25 @@ partial class FHome
         comparisonContainerGroupBox.TabStop = false;
         comparisonContainerGroupBox.Text = "Comparison COMP0001";
         // 
-        // compareButton
+        // comparisonResultsGroupBox
         // 
-        compareButton.Location = new Point(616, 62);
-        compareButton.Name = "compareButton";
-        compareButton.Size = new Size(142, 23);
-        compareButton.TabIndex = 2;
-        compareButton.Text = "Comparer";
-        compareButton.UseVisualStyleBackColor = true;
+        comparisonResultsGroupBox.Controls.Add(comparisonDataGridView);
+        comparisonResultsGroupBox.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
+        comparisonResultsGroupBox.Location = new Point(6, 186);
+        comparisonResultsGroupBox.Name = "comparisonResultsGroupBox";
+        comparisonResultsGroupBox.Size = new Size(764, 205);
+        comparisonResultsGroupBox.TabIndex = 4;
+        comparisonResultsGroupBox.TabStop = false;
+        comparisonResultsGroupBox.Text = "Resultat";
+        // 
+        // comparisonDataGridView
+        // 
+        comparisonDataGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+        comparisonDataGridView.Dock = DockStyle.Fill;
+        comparisonDataGridView.Location = new Point(3, 19);
+        comparisonDataGridView.Name = "comparisonDataGridView";
+        comparisonDataGridView.Size = new Size(758, 183);
+        comparisonDataGridView.TabIndex = 3;
         // 
         // planStatusGroupBox
         // 
@@ -327,24 +349,16 @@ partial class FHome
         planStatusGroupBox.TabStop = false;
         planStatusGroupBox.Text = "Statut de plans";
         // 
-        // clientPlanStatusLabel
+        // empPlanStatusValueLabel
         // 
-        clientPlanStatusLabel.AutoSize = true;
-        clientPlanStatusLabel.Location = new Point(15, 19);
-        clientPlanStatusLabel.Name = "clientPlanStatusLabel";
-        clientPlanStatusLabel.Size = new Size(94, 15);
-        clientPlanStatusLabel.TabIndex = 0;
-        clientPlanStatusLabel.Text = "Plan Client est : ";
-        // 
-        // clientPlanStatusValueLabel
-        // 
-        clientPlanStatusValueLabel.AutoSize = true;
-        clientPlanStatusValueLabel.ForeColor = Color.Red;
-        clientPlanStatusValueLabel.Location = new Point(103, 19);
-        clientPlanStatusValueLabel.Name = "clientPlanStatusValueLabel";
-        clientPlanStatusValueLabel.Size = new Size(72, 15);
-        clientPlanStatusValueLabel.TabIndex = 0;
-        clientPlanStatusValueLabel.Text = "Introuvable";
+        empPlanStatusValueLabel.AutoSize = true;
+        empPlanStatusValueLabel.ForeColor = Color.Red;
+        empPlanStatusValueLabel.Location = new Point(282, 19);
+        empPlanStatusValueLabel.Name = "empPlanStatusValueLabel";
+        empPlanStatusValueLabel.Size = new Size(72, 15);
+        empPlanStatusValueLabel.TabIndex = 0;
+        empPlanStatusValueLabel.Text = "Introuvable";
+        empPlanStatusValueLabel.Click += empPlanStatusValueLabel_Click;
         // 
         // empPlanStatusLabel
         // 
@@ -355,35 +369,25 @@ partial class FHome
         empPlanStatusLabel.TabIndex = 0;
         empPlanStatusLabel.Text = "Plan EMP est : ";
         // 
-        // empPlanStatusValueLabel
+        // clientPlanStatusValueLabel
         // 
-        empPlanStatusValueLabel.AutoSize = true;
-        empPlanStatusValueLabel.ForeColor = Color.Red;
-        empPlanStatusValueLabel.Location = new Point(282, 19);
-        empPlanStatusValueLabel.Name = "empPlanStatusValueLabel";
-        empPlanStatusValueLabel.Size = new Size(72, 15);
-        empPlanStatusValueLabel.TabIndex = 0;
-        empPlanStatusValueLabel.Text = "Introuvable";
+        clientPlanStatusValueLabel.AutoSize = true;
+        clientPlanStatusValueLabel.ForeColor = Color.Red;
+        clientPlanStatusValueLabel.Location = new Point(103, 19);
+        clientPlanStatusValueLabel.Name = "clientPlanStatusValueLabel";
+        clientPlanStatusValueLabel.Size = new Size(72, 15);
+        clientPlanStatusValueLabel.TabIndex = 0;
+        clientPlanStatusValueLabel.Text = "Introuvable";
+        clientPlanStatusValueLabel.Click += clientPlanStatusValueLabel_Click;
         // 
-        // comparisonDataGridView
+        // clientPlanStatusLabel
         // 
-        comparisonDataGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-        comparisonDataGridView.Dock = DockStyle.Fill;
-        comparisonDataGridView.Location = new Point(3, 19);
-        comparisonDataGridView.Name = "comparisonDataGridView";
-        comparisonDataGridView.Size = new Size(758, 183);
-        comparisonDataGridView.TabIndex = 3;
-        // 
-        // comparisonResultsGroupBox
-        // 
-        comparisonResultsGroupBox.Controls.Add(comparisonDataGridView);
-        comparisonResultsGroupBox.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
-        comparisonResultsGroupBox.Location = new Point(6, 186);
-        comparisonResultsGroupBox.Name = "comparisonResultsGroupBox";
-        comparisonResultsGroupBox.Size = new Size(764, 205);
-        comparisonResultsGroupBox.TabIndex = 4;
-        comparisonResultsGroupBox.TabStop = false;
-        comparisonResultsGroupBox.Text = "Resultat";
+        clientPlanStatusLabel.AutoSize = true;
+        clientPlanStatusLabel.Location = new Point(15, 19);
+        clientPlanStatusLabel.Name = "clientPlanStatusLabel";
+        clientPlanStatusLabel.Size = new Size(94, 15);
+        clientPlanStatusLabel.TabIndex = 0;
+        clientPlanStatusLabel.Text = "Plan Client est : ";
         // 
         // FHome
         // 
@@ -400,10 +404,10 @@ partial class FHome
         generalInfoGroupBox.ResumeLayout(false);
         generalInfoGroupBox.PerformLayout();
         comparisonContainerGroupBox.ResumeLayout(false);
+        comparisonResultsGroupBox.ResumeLayout(false);
+        ((System.ComponentModel.ISupportInitialize)comparisonDataGridView).EndInit();
         planStatusGroupBox.ResumeLayout(false);
         planStatusGroupBox.PerformLayout();
-        ((System.ComponentModel.ISupportInitialize)comparisonDataGridView).EndInit();
-        comparisonResultsGroupBox.ResumeLayout(false);
         ResumeLayout(false);
         PerformLayout();
     }

--- a/Mira.UI/FHome.cs
+++ b/Mira.UI/FHome.cs
@@ -1,9 +1,112 @@
+using Mira.Core;
+
 namespace Mira.UI;
 
 public partial class FHome : Form
 {
+    private bool ClientreportLoaded = false;
+    private bool EMPreportLoaded = false;
+    private string ClientReportGeneratedName = string.Empty;
+    private string EMPReportGeneratedName = string.Empty;
+
     public FHome()
     {
         InitializeComponent();
+        CheckDirectories();
+        InitializeStatusLabelCursors();
+    }
+
+    private void CheckDirectories()
+    {
+        //check if he directory Data is present else create it, then checks for directory Reports inside Data
+        if (!Directory.Exists(Paths.DataDirectory))
+        {
+            Directory.CreateDirectory(Paths.DataDirectory);
+        }
+        if (!Directory.Exists(Paths.ReportsDirectory))
+        {
+            Directory.CreateDirectory(Paths.ReportsDirectory);
+        }
+
+    }
+
+    private void InitializeStatusLabelCursors()
+    {
+        // Set default cursors for status labels based on initial load state
+        UpdateStatusLabelCursor(clientPlanStatusValueLabel, ClientreportLoaded);
+        UpdateStatusLabelCursor(empPlanStatusValueLabel, EMPreportLoaded);
+    }
+
+    private void UpdateStatusLabelCursor(Label statusLabel, bool isLoaded)
+    {
+        // Change cursor to hand if loaded, otherwise use default arrow cursor
+        statusLabel.Cursor = isLoaded ? Cursors.Hand : Cursors.Default;
+    }
+
+    private void ImportFile(Enums.ReportType reportType, ref bool reportLoaded, ref string generatedName)
+    {
+
+        //Copy file to Reports directory with a unique name based on the report type and current timestamp
+        using (OpenFileDialog openFileDialog = new OpenFileDialog())
+        {
+            openFileDialog.Title = "Select Report File";
+            openFileDialog.Filter = "All Files (*.pdf)|*.pdf";
+            if (openFileDialog.ShowDialog() == DialogResult.OK)
+            {
+                string sourceFilePath = openFileDialog.FileName;
+                string fileExtension = Path.GetExtension(sourceFilePath);
+                string timeStamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                string destFileName = $"{reportType}_Report_{timeStamp}{fileExtension}";
+                string destFilePath = Path.Combine(Paths.ReportsDirectory, destFileName);
+                File.Copy(sourceFilePath, destFilePath);
+                generatedName = destFileName;
+                reportLoaded = true;
+                MessageBox.Show($"{reportType} report imported successfully!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
+    }
+
+    private void importClientPlanToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        ImportFile(Enums.ReportType.Client, ref ClientreportLoaded, ref ClientReportGeneratedName);
+        clientPlanStatusValueLabel.Text = ClientreportLoaded ? "Loaded" : "Not Loaded";
+        clientPlanStatusValueLabel.ForeColor = ClientreportLoaded ? Color.Green : Color.Red;
+        UpdateStatusLabelCursor(clientPlanStatusValueLabel, ClientreportLoaded);
+    }
+
+    private void importEmpPlanToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        ImportFile(Enums.ReportType.EMP, ref EMPreportLoaded, ref EMPReportGeneratedName);
+        empPlanStatusValueLabel.Text = EMPreportLoaded ? "Loaded" : "Not Loaded";
+        empPlanStatusValueLabel.ForeColor = EMPreportLoaded ? Color.Green : Color.Red;
+        UpdateStatusLabelCursor(empPlanStatusValueLabel, EMPreportLoaded);
+    }
+
+    private void clientPlanStatusValueLabel_Click(object sender, EventArgs e)
+    {
+        if (ClientreportLoaded)
+        {
+            // Open the client report file
+            string filePath = Path.Combine(Paths.ReportsDirectory, ClientReportGeneratedName);
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+            {
+                FileName = filePath,
+                UseShellExecute = true
+            });
+
+        }
+    }
+
+    private void empPlanStatusValueLabel_Click(object sender, EventArgs e)
+    {
+        if (EMPreportLoaded)
+        {
+            string filePath = Path.Combine(Paths.ReportsDirectory, EMPReportGeneratedName);
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+            {
+                FileName = filePath,
+                UseShellExecute = true
+            });
+        }
     }
 }

--- a/Mira.UI/FHome.resx
+++ b/Mira.UI/FHome.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="mainMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>

--- a/Mira.UI/Mira.UI.csproj
+++ b/Mira.UI/Mira.UI.csproj
@@ -8,4 +8,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\Mira.Core\Mira.Core.csproj" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Introduced the ability to import and manage client and EMP reports:
- Removed `Class1` from `Class1.cs`.
- Added `Paths` class for directory management and `Enums` for report types.
- Updated `FHome.Designer.cs` to include new controls (`compareButton`, `comparisonResultsGroupBox`, `comparisonDataGridView`) and reorganized layout.
- Added event handlers for importing reports and interacting with status labels.
- Implemented `CheckDirectories` to ensure directory structure and `ImportFile` for file import logic.
- Updated `FHome.resx` and added a project reference to `Mira.Core` in `Mira.UI.csproj`.

These changes improve the application's usability and maintainability.