### PR TITLE
Add HTTP-based PDF comparison via OpenAI API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ secrets.json
 appsettings.local.json
 **/appsettings.local.json
 
+# Generated preview images
+**/PreviewImages/
+
 # Build results
 [Dd]ebug/
 [Rr]elease/

--- a/Mira.Core/Services/ChatGptHttpService.cs
+++ b/Mira.Core/Services/ChatGptHttpService.cs
@@ -1,0 +1,542 @@
+﻿using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Mira.Core.Services;
+
+/// <summary>
+/// ChatGPT service using direct HTTP calls for better control and transparency
+/// </summary>
+public class ChatGptHttpService
+{
+    #region Configuration Constants
+
+    // OpenAI Responses API Configuration
+    private const string OpenAiApiUrl = "https://api.openai.com/v1/responses";
+    private const string DefaultModel = "gpt-4.1"; // Recommended model for this use case
+    private const int MaxOutputTokens = 12000; // Enough for 13 detailed tables
+    private const float DefaultTemperature = 0.1f; // Deterministic, low-variance output
+    private const int TimeoutMinutes = 10; // Allow long multi-image requests
+
+    #endregion
+
+    #region Private Fields
+
+    private readonly ILoggerService _logger;
+    private readonly HttpClient _httpClient;
+    private string? _apiKey;
+    private string? _outputDirectory;
+
+    #endregion
+
+    #region Properties
+
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(_apiKey);
+
+    #endregion
+
+    #region Constructor
+
+    public ChatGptHttpService(ILoggerService logger)
+    {
+        _logger = logger;
+        _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromMinutes(TimeoutMinutes)
+        };
+        _logger.LogInfo($"ChatGPT HTTP service initialized (Model: {DefaultModel}, Timeout: {TimeoutMinutes}min)");
+    }
+
+    #endregion
+
+    #region Public Methods
+
+    public void SetApiKey(string apiKey)
+    {
+        _logger.LogDebug("Setting API key for HTTP service");
+        _apiKey = apiKey;
+        _httpClient.DefaultRequestHeaders.Authorization =
+     new AuthenticationHeaderValue("Bearer", apiKey);
+        _logger.LogInfo($"API key configured for HTTP service (Model: {DefaultModel})");
+    }
+
+    public void SetOutputDirectory(string outputDirectory)
+    {
+        _logger.LogInfo($"Setting output directory for HTTP service: {outputDirectory}");
+        _outputDirectory = outputDirectory;
+    }
+
+    /// <summary>
+    /// Compares two PDFs by converting them to images and sending via HTTP
+    /// </summary>
+    public async Task<string> ComparePdfDocumentsAsync(
+   string clientPdfPath,
+        string supplierPdfPath,
+    IProgress<string>? progressCallback = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInfo($"=== HTTP COMPARISON: {clientPdfPath} vs {supplierPdfPath} ===");
+        progressCallback?.Report("Starting HTTP-based PDF comparison...");
+
+        ValidateConfiguration();
+        ValidateFiles(clientPdfPath, supplierPdfPath);
+
+        try
+        {
+            // Convert PDFs to images
+            progressCallback?.Report("Converting PDFs to images...");
+            var pdfImageService = new PdfImageService(_logger);
+
+            var clientImages = pdfImageService.ConvertPdfToImages(clientPdfPath);
+            var supplierImages = pdfImageService.ConvertPdfToImages(supplierPdfPath);
+
+            _logger.LogInfo($"Client: {clientImages.Count} pages, Supplier: {supplierImages.Count} pages");
+
+            // Use the main comparison method
+            return await ComparePdfDocumentsViaHttpAsync(clientImages, supplierImages, progressCallback, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($">>> HTTP COMPARISON FAILED: {ex.Message} <<<", ex);
+            progressCallback?.Report($"Comparison failed: {ex.Message}");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Compares pre-converted images via HTTP (main comparison method)
+    /// </summary>
+    public async Task<string> ComparePdfDocumentsViaHttpAsync(
+ List<byte[]> clientImages,
+        List<byte[]> supplierImages,
+        IProgress<string>? progressCallback = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInfo($"=== HTTP IMAGE COMPARISON: {clientImages.Count} client + {supplierImages.Count} supplier pages ===");
+
+        ValidateConfiguration();
+
+        try
+        {
+            // Build and serialize request
+            progressCallback?.Report("Building HTTP request with all images...");
+            var requestPayload = BuildComparisonRequest(clientImages, supplierImages);
+            var jsonPayload = SerializeRequest(requestPayload);
+
+            LogRequestMetrics(jsonPayload, clientImages, supplierImages);
+            LogPromptToFile(clientImages, supplierImages);
+
+            // Send HTTP request
+            progressCallback?.Report($"Sending HTTP request with {clientImages.Count + supplierImages.Count} images...");
+            var response = await SendHttpRequestAsync(jsonPayload, cancellationToken);
+
+            // Parse and validate response
+            progressCallback?.Report("Parsing response from ChatGPT...");
+            var result = await ParseResponseAsync(response, cancellationToken);
+
+            progressCallback?.Report("Comparison completed successfully!");
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($">>> HTTP IMAGE COMPARISON FAILED: {ex.Message} <<<", ex);
+            progressCallback?.Report($"Comparison failed: {ex.Message}");
+            throw;
+        }
+    }
+
+    #endregion
+
+    #region Private Helper Methods - Validation
+
+    private void ValidateConfiguration()
+    {
+        if (!IsConfigured)
+        {
+            throw new InvalidOperationException("API key not configured");
+        }
+    }
+
+    private void ValidateFiles(string clientPdfPath, string supplierPdfPath)
+    {
+        if (!File.Exists(clientPdfPath) || !File.Exists(supplierPdfPath))
+        {
+            throw new FileNotFoundException("One or both PDF files not found");
+        }
+    }
+
+    #endregion
+
+    #region Private Helper Methods - Request Building
+
+    private OpenAiChatRequest BuildComparisonRequest(List<byte[]> clientImages, List<byte[]> supplierImages)
+    {
+        string systemPrompt = GetSystemPrompt();
+        string userPrompt = GetUserPrompt();
+
+        // Build input array for Responses API
+        var inputItems = new List<object>();
+
+        // Add system instructions as the first item
+        inputItems.Add(new
+        {
+            role = "system",
+            content = new[]
+ {
+       new { type = "input_text", text = systemPrompt }
+            }
+        });
+
+        // Build user message content
+        var userContentList = new List<object>
+        {
+          new { type = "input_text", text = userPrompt },
+         new { type = "input_text", text = "\n\n=== DOCUMENT CLIENT (RÉFÉRENCE MAÎTRE) ===\n" }
+        };
+
+        // Add client images
+        AddImagesToInputContent(userContentList, clientImages, "CLIENT");
+        userContentList.Add(new { type = "input_text", text = "\n=== FIN DOCUMENT CLIENT ===\n" });
+        userContentList.Add(new { type = "input_text", text = "\n=== DOCUMENT FOURNISSEUR ===\n" });
+
+        // Add supplier images
+        AddImagesToInputContent(userContentList, supplierImages, "FOURNISSEUR");
+        userContentList.Add(new { type = "input_text", text = "\n=== FIN DOCUMENT FOURNISSEUR ===\n" });
+
+        // Add user message
+        inputItems.Add(new
+        {
+            role = "user",
+            content = userContentList.ToArray()
+        });
+
+        return new OpenAiChatRequest
+        {
+            Model = DefaultModel,
+            Input = inputItems.ToArray(),
+            MaxTokens = MaxOutputTokens,
+            Temperature = DefaultTemperature
+        };
+    }
+
+    private void AddImagesToInputContent(List<object> content, List<byte[]> images, string documentType)
+    {
+        for (int i = 0; i < images.Count; i++)
+        {
+            content.Add(new
+            {
+                type = "input_text",
+                text = $"\n--- {documentType} PAGE {i + 1}/{images.Count} ---\n"
+            });
+
+            content.Add(new
+            {
+                type = "input_image",
+                image_url = $"data:image/png;base64,{Convert.ToBase64String(images[i])}"
+            });
+        }
+    }
+
+    private string SerializeRequest(OpenAiChatRequest request)
+    {
+        return JsonSerializer.Serialize(request, new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        });
+    }
+
+    #endregion
+
+    #region Private Helper Methods - HTTP Communication
+
+    private async Task<HttpResponseMessage> SendHttpRequestAsync(string jsonPayload, CancellationToken cancellationToken)
+    {
+        var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+
+        _logger.LogInfo(">>> SENDING HTTP POST TO OPENAI API <<<");
+        var response = await _httpClient.PostAsync(OpenAiApiUrl, content, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError($"HTTP Error {response.StatusCode}: {errorContent}");
+            throw new HttpRequestException($"OpenAI API returned {response.StatusCode}: {errorContent}");
+        }
+
+        return response;
+    }
+
+    private async Task<string> ParseResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        var apiResponse = JsonSerializer.Deserialize<OpenAiChatResponse>(responseContent);
+
+        if (apiResponse?.Output == null || apiResponse.Output.Count == 0)
+        {
+            throw new Exception("No response from OpenAI API");
+        }
+
+        // Find the assistant message in output
+        var assistantOutput = apiResponse.Output.FirstOrDefault(o => o.Role == "assistant");
+        if (assistantOutput == null || assistantOutput.Content == null || assistantOutput.Content.Count == 0)
+        {
+            throw new Exception("No assistant message in response");
+        }
+
+        // Extract text from output_text content
+        var textContent = assistantOutput.Content.FirstOrDefault(c => c.Type == "output_text");
+        if (textContent == null)
+        {
+            throw new Exception("No text content in response");
+        }
+
+        var result = textContent.Text;
+        _logger.LogInfo($">>> HTTP COMPARISON SUCCESS: {result.Length} characters <<<");
+
+        // Log token usage
+        if (apiResponse.Usage != null)
+        {
+            _logger.LogInfo($"Token usage - Input: {apiResponse.Usage.PromptTokens}, " +
+             $"Output: {apiResponse.Usage.CompletionTokens}, " +
+                          $"Total: {apiResponse.Usage.TotalTokens}");
+        }
+
+        return result;
+    }
+
+    #endregion
+
+    #region Private Helper Methods - Logging
+
+    private void LogRequestMetrics(string jsonPayload, List<byte[]> clientImages, List<byte[]> supplierImages)
+    {
+        _logger.LogInfo($"HTTP Payload size: {jsonPayload.Length / 1024.0:F2} KB");
+        _logger.LogInfo($"Total images in payload: {clientImages.Count + supplierImages.Count}");
+        _logger.LogInfo($"Using model: {DefaultModel}");
+    }
+
+    private void LogPromptToFile(List<byte[]> clientImages, List<byte[]> supplierImages)
+    {
+        _logger.LogInfo(">>> LOGGING COMPLETE PROMPT SENT TO CHATGPT (HTTP) <<<");
+
+        var promptLog = new StringBuilder();
+        promptLog.AppendLine("================================================================================");
+        promptLog.AppendLine($"COMPLETE PROMPT SENT TO CHATGPT API (HTTP METHOD)");
+        promptLog.AppendLine($"Model: {DefaultModel} | Max Tokens: {MaxOutputTokens} | Temperature: {DefaultTemperature}");
+        promptLog.AppendLine("================================================================================");
+        promptLog.AppendLine();
+        promptLog.AppendLine("=== SYSTEM MESSAGE (Expert Role) ===");
+        promptLog.AppendLine(GetSystemPrompt());
+        promptLog.AppendLine();
+        promptLog.AppendLine("=== USER MESSAGE ===");
+        promptLog.AppendLine(GetUserPrompt());
+        promptLog.AppendLine();
+        promptLog.AppendLine("\n\n=== DOCUMENT CLIENT (RÉFÉRENCE MAÎTRE) ===\n");
+
+        LogImagesMetadata(promptLog, clientImages, "CLIENT");
+
+        promptLog.AppendLine("\n=== FIN DOCUMENT CLIENT ===\n");
+        promptLog.AppendLine("\n=== DOCUMENT FOURNISSEUR ===\n");
+
+        LogImagesMetadata(promptLog, supplierImages, "FOURNISSEUR");
+
+        promptLog.AppendLine("\n=== FIN DOCUMENT FOURNISSEUR ===\n");
+        promptLog.AppendLine();
+        promptLog.AppendLine("================================================================================");
+        promptLog.AppendLine($"Total images sent: {clientImages.Count + supplierImages.Count}");
+        promptLog.AppendLine($"Client images: {clientImages.Count}");
+        promptLog.AppendLine($"Supplier images: {supplierImages.Count}");
+        promptLog.AppendLine($"Total payload size: {(clientImages.Sum(i => i.Length) + supplierImages.Sum(i => i.Length)) / 1024.0:F2} KB");
+        promptLog.AppendLine("================================================================================");
+
+        _logger.LogChatGptResponse("PROMPT_SENT_HTTP", promptLog.ToString());
+        _logger.LogInfo(">>> PROMPT LOGGED TO CHATGPT LOG FILE <<<");
+    }
+
+    private void LogImagesMetadata(StringBuilder log, List<byte[]> images, string documentType)
+    {
+        for (int i = 0; i < images.Count; i++)
+        {
+            log.AppendLine($"\n--- {documentType} PAGE {i + 1}/{images.Count} ---");
+            log.AppendLine($"[IMAGE: {documentType} image {i + 1} - {images[i].Length / 1024.0:F2} KB - Base64 encoded]");
+        }
+    }
+
+    #endregion
+
+    #region Private Helper Methods - Prompts
+
+    private string GetSystemPrompt()
+    {
+        return @"Tu es un expert senior en qualité et ingénierie technique spécialisé dans les revues de conformité technique indépendantes.
+
+Tu possèdes une expertise approfondie dans l'analyse comparative de documents techniques industriels, incluant les plans mécaniques, spécifications dimensionnelles, exigences matériaux, et normes de qualité.
+
+Tu travailles avec rigueur et précision, en te basant uniquement sur les informations présentes dans les documents fournis.";
+    }
+
+    private string GetUserPrompt()
+    {
+        return @"CONTEXTE :
+
+Deux documents techniques sont fournis :
+
+1) Document CLIENT (référence maître, exigences contractuelles)
+2) Document FOURNISSEUR (document dérivé, exécution ou fabrication)
+
+OBJECTIF :
+
+Réaliser une revue complète de conformité du document fournisseur par rapport au document client.
+
+RÈGLES GÉNÉRALES :
+
+- Le document client est la référence maître absolue
+- Évaluer les exigences techniques, dimensionnelles, fonctionnelles, de sécurité et qualité
+- Utiliser une terminologie technique professionnelle applicable à tout secteur industriel
+- Te baser UNIQUEMENT sur le contenu des documents fournis
+- Les images fournies sont des scans haute résolution des documents techniques originaux
+
+NIVEAU DE DÉTAIL ATTENDU (TRÈS IMPORTANT) :
+
+- Aller dans le DÉTAIL POUR CHAQUE PIÈCE / REPÈRE des plans
+- Pour chaque pièce, détailler au minimum :
+ - Nom / repère / identifiant de la pièce
+ - Toutes les cotes importantes visibles (dimensions principales, épaisseurs, diamètres, entraxes, rayons, etc.)
+ - Toutes les tolérances associées (dimensionnelles, géométriques, état de surface)
+ - Les matériaux et traitements associés à la pièce
+ - Les fonctions principales de la pièce (portante, guidage, étanchéité, liaison, sécurité, etc.)
+ - Les interfaces de la pièce avec les autres pièces (ajustements, jeux, serrages, type d’assemblage)
+ - Les notes spécifiques ou remarques techniques associées à la pièce
+- Comparer pièce par pièce : pour chaque repère, indiquer clairement les différences entre Client et Fournisseur
+- Si une pièce existe dans un document et pas dans l’autre, le signaler explicitement comme non conforme
+- Si des informations sont manquantes pour une pièce (matière, traitement, cote critique, tolérance), les signaler explicitement
+
+FORMAT DE SORTIE STRICT (OBLIGATOIRE) :
+
+- Sortie sous forme de TABLEAUX UNIQUEMENT
+- AUCUN texte explicatif, résumé ou conclusion
+- AUCUNE liste à puces
+- AUCUN emoji
+- Chaque tableau doit comporter EXACTEMENT3 colonnes : | Client | Fournisseur | Statut |
+- Le champ ""Statut"" doit contenir uniquement : ""Conforme"" ou ""Non conforme""
+
+STRUCTURE DE SORTIE OBLIGATOIRE (UN TABLEAU PAR SECTION) :
+
+1) Références générales et périmètre
+2) Nomenclature / liste des pièces (inclure un niveau de détail par pièce : repère, désignation, quantité, version, indice de révision)
+3) Matériaux
+4) Traitements thermiques et traitements de surface
+5) Tolérances dimensionnelles et états de surface
+6) Exigences fonctionnelles et mécaniques
+7) Exigences d'essais et de validation
+8) Sécurité, avertissements et marquages réglementaires
+9) Identification, marquage et traçabilité
+10) Conformité réglementaire et documentation obligatoire
+11) Conditionnement, manutention et protection
+12) Documentation qualité et livrables
+13) Vérification dimensionnelle de chaque repère
+ - vérification de toutes les cotes par pièce
+ - cotes critiques et fonctionnelles
+ - interfaces et ajustements
+ - méthodes de mesure
+ - rapports de contrôle dimensionnel
+ - conformité dimensionnelle avant essais ou mise en service
+
+RÈGLES D'ÉVALUATION :
+
+- Si l'exigence fournisseur correspond totalement à l'exigence client → ""Conforme""
+- Si une information est manquante, ambiguë ou différente → ""Non conforme""
+- En cas de différence d'unités (métrique/impérial), indiquer ""Conforme"" uniquement si l'équivalence technique est démontrée
+- Reprendre la terminologie exacte des documents lorsque possible
+
+EXIGENCES FINALES :
+
+- Tableaux uniquement
+- Mise en forme claire et cohérente
+- Aucun texte avant ou après les tableaux";
+    }
+
+    #endregion
+}
+#region OpenAI API Models
+
+public class OpenAiChatRequest
+{
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = "gpt-4.1";
+
+    [JsonPropertyName("input")]
+    public object[]? Input { get; set; }
+
+    [JsonPropertyName("max_output_tokens")]
+    public int MaxTokens { get; set; } = 12000;
+
+    [JsonPropertyName("temperature")]
+    public float Temperature { get; set; } = 0.1f;
+}
+
+public class OpenAiChatResponse
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("object")]
+    public string Object { get; set; } = string.Empty;
+
+    [JsonPropertyName("created_at")]
+    public long CreatedAt { get; set; }
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("output")]
+    public List<ResponseOutput> Output { get; set; } = new();
+
+    [JsonPropertyName("usage")]
+    public Usage? Usage { get; set; }
+}
+
+public class ResponseOutput
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("role")]
+    public string Role { get; set; } = string.Empty;
+
+    [JsonPropertyName("content")]
+    public List<ResponseContent> Content { get; set; } = new();
+}
+
+public class ResponseContent
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = string.Empty;
+
+    [JsonPropertyName("annotations")]
+    public List<object> Annotations { get; set; } = new();
+}
+
+public class Usage
+{
+    [JsonPropertyName("input_tokens")]
+    public int PromptTokens { get; set; }
+
+    [JsonPropertyName("output_tokens")]
+    public int CompletionTokens { get; set; }
+
+    [JsonPropertyName("total_tokens")]
+    public int TotalTokens { get; set; }
+}
+
+#endregion

--- a/Mira.Core/Services/ChatGptService.cs
+++ b/Mira.Core/Services/ChatGptService.cs
@@ -6,11 +6,45 @@ namespace Mira.Core.Services;
 
 public interface IChatGptService
 {
+    /// <summary>
+    /// Sends a message to ChatGPT and returns the response
+    /// </summary>
     Task<string> SendMessageAsync(string message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Analyzes a PDF file by uploading it to OpenAI
+    /// </summary>
     Task<string> AnalyzePdfFileAsync(string pdfFilePath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Compares two PDF documents (client vs supplier) and generates a conformity report
+    /// </summary>
+    /// <param name="clientPdfPath">Path to the client PDF file</param>
+    /// <param name="supplierPdfPath">Path to the supplier PDF file</param>
+    /// <param name="progressCallback">Optional callback to report progress</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task<string> ComparePdfDocumentsAsync(string clientPdfPath, string supplierPdfPath, 
+      IProgress<string>? progressCallback = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Tests the connection to the ChatGPT API
+    /// </summary>
     Task<bool> TestConnectionAsync();
+
+    /// <summary>
+    /// Sets the API key for ChatGPT
+    /// </summary>
     void SetApiKey(string apiKey);
+
+    /// <summary>
+    /// Gets whether an API key is configured
+    /// </summary>
     bool IsConfigured { get; }
+    
+    /// <summary>
+    /// Sets the output directory where images should be saved
+    /// </summary>
+    void SetOutputDirectory(string outputDirectory);
 }
 
 public class ChatGptService : IChatGptService
@@ -21,7 +55,9 @@ public class ChatGptService : IChatGptService
     private OpenAIFileClient? _fileClient;
     private readonly ILoggerService _logger;
     private readonly IPdfImageService _pdfImageService;
-    private const string DefaultModel = "gpt-4o-mini";
+    private readonly ChatGptHttpService _httpService;
+    private string? _outputDirectory;
+    private const string DefaultModel = "gpt-4o"; // Upgraded to latest GPT-4o
 
     public bool IsConfigured => !string.IsNullOrWhiteSpace(_apiKey);
 
@@ -29,7 +65,8 @@ public class ChatGptService : IChatGptService
     {
         _logger = logger;
         _pdfImageService = new PdfImageService(logger);
-        _logger.LogInfo("ChatGPT service initialized WITH PDF IMAGE SERVICE");
+        _httpService = new ChatGptHttpService(logger);
+        _logger.LogInfo("ChatGPT service initialized WITH PDF IMAGE SERVICE and HTTP SERVICE");
     }
 
     public void SetApiKey(string apiKey)
@@ -39,7 +76,64 @@ public class ChatGptService : IChatGptService
         _openAiClient = new OpenAIClient(apiKey);
         _chatClient = _openAiClient.GetChatClient(DefaultModel);
         _fileClient = _openAiClient.GetOpenAIFileClient();
+  
+        // Also set API key for HTTP service
+        _httpService.SetApiKey(apiKey);
+        
         _logger.LogInfo($"API key configured. Model: {DefaultModel}");
+    }
+    
+    public void SetOutputDirectory(string outputDirectory)
+    {
+        _logger.LogInfo($"Setting output directory for images: {outputDirectory}");
+     _outputDirectory = outputDirectory;
+    
+        // Ensure the images subdirectory exists
+        if (!string.IsNullOrEmpty(_outputDirectory))
+  {
+    string imagesDir = Path.Combine(_outputDirectory, "Images");
+  if (!Directory.Exists(imagesDir))
+    {
+     Directory.CreateDirectory(imagesDir);
+     _logger.LogInfo($"Created images directory: {imagesDir}");
+    }
+        }
+  
+        // Set output directory for HTTP service as well
+        _httpService.SetOutputDirectory(outputDirectory);
+    }
+
+    /// <summary>
+    /// Saves images to disk in the configured output directory
+    /// </summary>
+    private void SaveImages(List<byte[]> images, string prefix)
+    {
+        if (string.IsNullOrEmpty(_outputDirectory))
+        {
+            _logger.LogWarning("Output directory not set, skipping image save");
+            return;
+        }
+
+        string imagesDir = Path.Combine(_outputDirectory, "Images");
+        _logger.LogInfo($"Saving {images.Count} images with prefix '{prefix}' to: {imagesDir}");
+
+        for (int i = 0; i < images.Count; i++)
+        {
+            string fileName = $"{prefix}_page_{i + 1:D3}.png";
+            string filePath = Path.Combine(imagesDir, fileName);
+            
+            try
+            {
+                File.WriteAllBytes(filePath, images[i]);
+                _logger.LogDebug($"Saved image: {fileName} ({images[i].Length / 1024.0:F2} KB)");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to save image {fileName}", ex);
+            }
+        }
+        
+        _logger.LogInfo($"Successfully saved {images.Count} images");
     }
 
     public async Task<string> SendMessageAsync(string message, CancellationToken cancellationToken = default)
@@ -91,51 +185,136 @@ public class ChatGptService : IChatGptService
 
         try
         {
-            // CONVERT PDF TO IMAGES
-            _logger.LogInfo(">>> CONVERTING PDF TO IMAGES <<<");
+    // CONVERT PDF TO IMAGES
+       _logger.LogInfo(">>> CONVERTING PDF TO IMAGES <<<");
             var imageByteArrays = _pdfImageService.ConvertPdfToImages(pdfFilePath);
-            _logger.LogInfo($">>> CONVERTED TO {imageByteArrays.Count} IMAGES <<<");
+_logger.LogInfo($">>> CONVERTED TO {imageByteArrays.Count} IMAGES <<<");
 
-            // Take first 5 pages to stay within token limits
-            var pagesToAnalyze = imageByteArrays.Take(5).ToList();
+            // Save ALL images to disk BEFORE sending
+    string pdfFileName = Path.GetFileNameWithoutExtension(pdfFilePath);
+   SaveImages(imageByteArrays, pdfFileName);
+            _logger.LogInfo(">>> ALL IMAGES SAVED TO DISK <<<");
+
+ // Take first 5 pages to stay within token limits
+    var pagesToAnalyze = imageByteArrays.Take(5).ToList();
             
-            // BUILD MESSAGE WITH TEXT + IMAGES
-            var contentParts = new List<ChatMessageContentPart>
+ // BUILD MESSAGE WITH TEXT + IMAGES
+      var contentParts = new List<ChatMessageContentPart>
             {
-                ChatMessageContentPart.CreateTextPart(
-                    "Analyze this technical PDF document. Provide a summary in EXACTLY 2 sentences. " +
-                    "Focus on the main technical content, key details, diagrams, images, and important information.")
+            ChatMessageContentPart.CreateTextPart(
+     "Analyze this technical PDF document. Provide a summary in EXACTLY 2 sentences. " +
+     "Focus on the main technical content, key details, diagrams, images, and important information.")
             };
 
-            // ADD IMAGES
-            foreach (var imageBytes in pagesToAnalyze)
+ // ADD IMAGES
+  foreach (var imageBytes in pagesToAnalyze)
             {
-                BinaryData imageData = BinaryData.FromBytes(imageBytes);
-                contentParts.Add(ChatMessageContentPart.CreateImagePart(imageData, "image/png"));
-                _logger.LogInfo($">>> ADDED IMAGE: {imageBytes.Length / 1024.0:F2} KB <<<");
-            }
+    BinaryData imageData = BinaryData.FromBytes(imageBytes);
+       contentParts.Add(ChatMessageContentPart.CreateImagePart(imageData, "image/png"));
+     _logger.LogInfo($">>> ADDED IMAGE: {imageBytes.Length / 1024.0:F2} KB <<<");
+         }
 
-            var messages = new List<ChatMessage>
+        var messages = new List<ChatMessage>
             {
-                new UserChatMessage(contentParts)
+        new UserChatMessage(contentParts)
             };
 
             _logger.LogInfo($">>> SENDING {pagesToAnalyze.Count} IMAGES TO CHATGPT <<<");
-            ChatCompletion completion = await _chatClient.CompleteChatAsync(messages, cancellationToken: cancellationToken);
+          ChatCompletion completion = await _chatClient.CompleteChatAsync(messages, cancellationToken: cancellationToken);
 
             string response = completion.Content[0].Text;
             _logger.LogInfo($">>> PDF ANALYSIS SUCCESS: {response} <<<");
             _logger.LogDebug($"Response: {response}");
 
-            return response;
+       return response;
         }
         catch (Exception ex)
         {
             _logger.LogError($">>> PDF ANALYSIS FAILED: {ex.Message} <<<", ex);
             throw new Exception($"Error analyzing PDF with ChatGPT: {ex.Message}", ex);
-        }
+  }
     }
 
+    public async Task<string> ComparePdfDocumentsAsync(string clientPdfPath, string supplierPdfPath, 
+  IProgress<string>? progressCallback = null, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInfo($"=== COMPARING TWO PDF DOCUMENTS (HTTP METHOD) ===");
+        _logger.LogInfo($"Client PDF: {clientPdfPath}");
+        _logger.LogInfo($"Supplier PDF: {supplierPdfPath}");
+     
+        progressCallback?.Report("Starting HTTP-based PDF comparison...");
+     
+        if (!IsConfigured)
+        {
+_logger.LogError("Attempted to compare PDFs without configured API key");
+        throw new InvalidOperationException("ChatGPT API key is not configured. Please set your API key first.");
+        }
+
+        if (!File.Exists(clientPdfPath))
+      {
+   _logger.LogError($"Client PDF file not found: {clientPdfPath}");
+            throw new FileNotFoundException($"Client PDF file not found: {clientPdfPath}");
+        }
+
+        if (!File.Exists(supplierPdfPath))
+   {
+            _logger.LogError($"Supplier PDF file not found: {supplierPdfPath}");
+     throw new FileNotFoundException($"Supplier PDF file not found: {supplierPdfPath}");
+        }
+
+   try
+ {
+    // CONVERT BOTH PDFs TO IMAGES
+            progressCallback?.Report("Converting Client PDF to images...");
+  _logger.LogInfo(">>> CONVERTING CLIENT PDF TO IMAGES <<<");
+            var clientImages = _pdfImageService.ConvertPdfToImages(clientPdfPath);
+     _logger.LogInfo($">>> CLIENT CONVERTED TO {clientImages.Count} IMAGES <<<");
+
+      progressCallback?.Report("Converting Supplier PDF to images...");
+          _logger.LogInfo(">>> CONVERTING SUPPLIER PDF TO IMAGES <<<");
+            var supplierImages = _pdfImageService.ConvertPdfToImages(supplierPdfPath);
+       _logger.LogInfo($">>> SUPPLIER CONVERTED TO {supplierImages.Count} IMAGES <<<");
+
+            // Save ALL images to disk BEFORE sending to API
+   progressCallback?.Report("Saving images to disk...");
+ string clientFileName = Path.GetFileNameWithoutExtension(clientPdfPath);
+  string supplierFileName = Path.GetFileNameWithoutExtension(supplierPdfPath);
+     _logger.LogInfo(">>> SAVING ALL IMAGES TO DISK BEFORE API CALL <<<");
+       SaveImages(clientImages, $"Client_{clientFileName}");
+            SaveImages(supplierImages, $"Supplier_{supplierFileName}");
+            _logger.LogInfo(">>> ALL IMAGES SAVED TO DISK <<<");
+
+            _logger.LogInfo($">>> USING HTTP SERVICE FOR COMPARISON <<<");
+            _logger.LogInfo($">>> SENDING ALL {clientImages.Count} CLIENT PAGES <<<");
+            _logger.LogInfo($">>> SENDING ALL {supplierImages.Count} SUPPLIER PAGES <<<");
+    
+            // Use HTTP service for the actual comparison
+    string response = await _httpService.ComparePdfDocumentsViaHttpAsync(
+         clientImages, 
+       supplierImages, 
+                progressCallback, 
+      cancellationToken);
+
+       _logger.LogInfo($">>> HTTP COMPARISON SUCCESS <<<");
+      _logger.LogInfo($"Response received: {response.Length} characters");
+     
+            progressCallback?.Report("Comparison completed successfully!");
+
+ return response;
+        }
+        catch (OperationCanceledException)
+      {
+  _logger.LogError(">>> PDF COMPARISON TIMEOUT - Operation exceeded 10 minutes <<<");
+   progressCallback?.Report("Comparison timed out after 10 minutes");
+      throw new TimeoutException("The comparison operation timed out after 10 minutes. The documents may be too large or complex.");
+        }
+ catch (Exception ex)
+        {
+   _logger.LogError($">>> PDF COMPARISON FAILED: {ex.Message} <<<", ex);
+     progressCallback?.Report($"Comparison failed: {ex.Message}");
+            throw new Exception($"Error comparing PDFs with ChatGPT: {ex.Message}", ex);
+        }
+    }
     public async Task<bool> TestConnectionAsync()
     {
         _logger.LogInfo("Testing connection to ChatGPT API");

--- a/Mira.UI/FHome.cs
+++ b/Mira.UI/FHome.cs
@@ -37,8 +37,8 @@ public partial class FHome : Form
         
         InitializeReportTypeMapping();
         InitializeUi();
-        LoadChatGptApiKey();
-        
+  LoadChatGptApiKey();
+ 
         _loggerService.LogInfo("Main form initialization completed");
     }
 
@@ -100,16 +100,16 @@ public partial class FHome : Form
 
                         if (isConnected)
                         {
-                            statusStripLabel.Text = "ChatGPT: Connected (GPT-4o mini) ✓";
-                            statusStripLabel.ForeColor = Color.Green;
-                            _loggerService.LogInfo("ChatGPT connection test successful");
-                        }
-                        else
-                        {
-                            statusStripLabel.Text = "ChatGPT: Connection failed ✗";
-                            statusStripLabel.ForeColor = Color.Red;
-                            _loggerService.LogWarning("ChatGPT connection test failed");
-                        }
+      statusStripLabel.Text = "ChatGPT: Connected (GPT-4o) ✓";
+      statusStripLabel.ForeColor = Color.Green;
+    _loggerService.LogInfo("ChatGPT connection test successful");
+             }
+           else
+  {
+    statusStripLabel.Text = "ChatGPT: Connection failed ✗";
+      statusStripLabel.ForeColor = Color.Red;
+  _loggerService.LogWarning("ChatGPT connection test failed");
+        }
                         return;
                     }
                 }
@@ -337,14 +337,19 @@ public partial class FHome : Form
     /// </summary>
     private void newComparisonToolStripMenuItem_Click(object sender, EventArgs e)
     {
-        _loggerService.LogInfo("User clicked new comparison menu item");
+     _loggerService.LogInfo("User clicked new comparison menu item");
         comparisonDto = new ComparisonDto();
         _loggerService.LogInfo($"New comparison created: {comparisonDto.Id}");
+        
+        // Set the output directory for ChatGPT service to save images
+        _chatGptService.SetOutputDirectory(comparisonDto.BaseReportDirectory);
+        _loggerService.LogInfo($"Output directory set for ChatGPT service: {comparisonDto.BaseReportDirectory}");
+        
         InitializeUi();
     }
 
     /// <summary>
-    /// Handles compare button click - analyzes both plans with ChatGPT
+    /// Handles compare button click - compares both plans with ChatGPT
     /// </summary>
     private async void compareButton_Click(object sender, EventArgs e)
     {
@@ -352,76 +357,133 @@ public partial class FHome : Form
 
         if (comparisonDto == null)
         {
-            _loggerService.LogWarning("Compare attempted without active comparison");
-            MessageBox.Show(
-                "Please create a new comparison first.",
-                "No Comparison",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Warning
-            );
-            return;
-        }
+       _loggerService.LogWarning("Compare attempted without active comparison");
+       MessageBox.Show(
+    "Please create a new comparison first.",
+    "No Comparison",
+        MessageBoxButtons.OK,
+        MessageBoxIcon.Warning
+ );
+        return;
+    }
 
         if (!comparisonDto.ClientPlanLoaded)
         {
-            _loggerService.LogWarning("Compare attempted without Client plan loaded");
-            MessageBox.Show(
+         _loggerService.LogWarning("Compare attempted without Client plan loaded");
+MessageBox.Show(
                 "Please import the Client plan first.",
-                "Client Plan Missing",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Warning
+      "Client Plan Missing",
+      MessageBoxButtons.OK,
+      MessageBoxIcon.Warning
             );
-            return;
-        }
+    return;
+    }
+
+        if (!comparisonDto.EmpPlanLoaded)
+        {
+            _loggerService.LogWarning("Compare attempted without EMP plan loaded");
+  MessageBox.Show(
+  "Please import the EMP/Supplier plan first.",
+        "EMP Plan Missing",
+                MessageBoxButtons.OK,
+    MessageBoxIcon.Warning
+   );
+          return;
+      }
 
         if (!_chatGptService.IsConfigured)
         {
-            _loggerService.LogWarning("Compare attempted without ChatGPT configured");
-            MessageBox.Show(
-                "ChatGPT is not configured. Please check your API key.",
-                "ChatGPT Not Configured",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Warning
+    _loggerService.LogWarning("Compare attempted without ChatGPT configured");
+          MessageBox.Show(
+        "ChatGPT is not configured. Please check your API key.",
+     "ChatGPT Not Configured",
+      MessageBoxButtons.OK,
+        MessageBoxIcon.Warning
             );
             return;
         }
 
         // Disable button during processing
         compareButton.Enabled = false;
-        compareButton.Text = "Analyzing...";
+  compareButton.Text = "Comparing...";
+  
+        // Create progress handler to update UI
+        var progress = new Progress<string>(status =>
+     {
+       statusStripLabel.Text = $"ChatGPT: {status}";
+          statusStripLabel.ForeColor = Color.Orange;
+    _loggerService.LogInfo($"Progress: {status}");
+ Application.DoEvents(); // Allow UI to update
+        });
 
         try
         {
-            _loggerService.LogInfo("Starting comparison analysis");
+     _loggerService.LogInfo("Starting comparison analysis");
 
-            // Analyze Client Plan
-            await AnalyzeClientPlanWithChatGpt(comparisonDto.ClientPlantPath);
+          statusStripLabel.Text = "ChatGPT: Initializing comparison...";
+            statusStripLabel.ForeColor = Color.Orange;
 
-            // If EMP plan is also loaded, analyze it
-            if (comparisonDto.EmpPlanLoaded)
-            {
-                _loggerService.LogInfo("Analyzing EMP plan as well");
-                await AnalyzeEmpPlanWithChatGpt(comparisonDto.EmpPlanPath);
-            }
+     // Get full file paths
+         string clientFilePath = Path.Combine(comparisonDto.BaseReportDirectory, comparisonDto.ClientPlantPath);
+            string empFilePath = Path.Combine(comparisonDto.BaseReportDirectory, comparisonDto.EmpPlanPath);
 
-            _loggerService.LogInfo("Comparison analysis completed");
-        }
-        catch (Exception ex)
-        {
-            _loggerService.LogError("Comparison analysis failed", ex);
+_loggerService.LogInfo($"Client path: {clientFilePath}");
+     _loggerService.LogInfo($"EMP path: {empFilePath}");
+
+        // Compare both documents WITH PROGRESS REPORTING
+string comparisonResult = await _chatGptService.ComparePdfDocumentsAsync(
+       clientFilePath, 
+                empFilePath, 
+progress);  // Pass progress callback
+
+ // Log the comparison result
+          _loggerService.LogInfo("Logging comparison result");
+        _loggerService.LogChatGptResponse($"Comparison_{comparisonDto.Id}", comparisonResult);
+
+            statusStripLabel.Text = "ChatGPT: Comparison completed successfully ✓";
+            statusStripLabel.ForeColor = Color.Green;
+
+ _loggerService.LogInfo("Comparison analysis completed successfully");
+
             MessageBox.Show(
-                $"Comparison failed:\n{ex.Message}",
-                "Error",
+     $"Comparison completed successfully!\n\nResponse length: {comparisonResult.Length} characters\n\nCheck the logs for detailed results.",
+             "Comparison Complete",
                 MessageBoxButtons.OK,
-                MessageBoxIcon.Error
-            );
+   MessageBoxIcon.Information
+     );
+     }
+    catch (TimeoutException ex)
+        {
+            _loggerService.LogError("Comparison timed out", ex);
+      statusStripLabel.Text = "ChatGPT: Comparison timed out ⏱";
+   statusStripLabel.ForeColor = Color.Red;
+          
+     MessageBox.Show(
+      $"The comparison operation timed out after 10 minutes.\n\nThis can happen with large or complex documents.\n\nDetails: {ex.Message}",
+  "Timeout Error",
+          MessageBoxButtons.OK,
+     MessageBoxIcon.Warning
+      );
         }
+      catch (Exception ex)
+   {
+         _loggerService.LogError("Comparison analysis failed", ex);
+    statusStripLabel.Text = "ChatGPT: Comparison failed ✗";
+      statusStripLabel.ForeColor = Color.Red;
+      
+            MessageBox.Show(
+ $"Comparison failed:\n\n{ex.Message}\n\nCheck the logs for more details.",
+          "Error",
+      MessageBoxButtons.OK,
+      MessageBoxIcon.Error
+    );
+  }
         finally
         {
-            // Re-enable button
+      // Re-enable button
             compareButton.Enabled = true;
-            compareButton.Text = "Comparer";
-        }
+     compareButton.Text = "Comparer";
+     }
     }
 
     /// <summary>


### PR DESCRIPTION
Introduce ChatGptHttpService for direct HTTP PDF comparison using OpenAI's responses API, enabling support for larger and more complex documents. Update IChatGptService and ChatGptService to support this workflow, including saving all images to disk for traceability. Enhance FHome UI for progress reporting, error handling, and user feedback during comparisons. Update .gitignore to exclude generated preview images. Switch default model to gpt-4o and improve logging throughout. These changes provide robust, auditable, and user-friendly technical PDF comparison capabilities.