### PR TITLE
Add extensible CSV export for ChatGPT responses

### DIFF
--- a/Mira.Core/Services/ChatGptHttpService.cs
+++ b/Mira.Core/Services/ChatGptHttpService.cs
@@ -2,6 +2,9 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.IO;
+using System.Linq;
 
 namespace Mira.Core.Services;
 
@@ -65,6 +68,14 @@ public class ChatGptHttpService
     {
         _logger.LogInfo($"Setting output directory for HTTP service: {outputDirectory}");
         _outputDirectory = outputDirectory;
+    }
+
+    // Response export is delegated to an exporter implementation. A default CSV exporter is used when none is set.
+    private IChatGptResponseExporter? _responseExporter;
+
+    public void SetResponseExporter(IChatGptResponseExporter exporter)
+    {
+        _responseExporter = exporter;
     }
 
     /// <summary>
@@ -135,6 +146,20 @@ public class ChatGptHttpService
             progressCallback?.Report("Parsing response from ChatGPT...");
             var result = await ParseResponseAsync(response, cancellationToken);
 
+            // Save response to CSV using configured exporter (non-fatal)
+            try
+            {
+                var fileName = $"Comparison_{DateTime.Now:yyyyMMdd_HHmmss}";
+                var savedPath = SaveChatGptResponseAsCsv(result, fileName);
+                _logger.LogInfo($"ChatGPT response exported to CSV: {savedPath}");
+                progressCallback?.Report($"CSV export saved: {savedPath}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to export ChatGPT response to CSV: {ex.Message}", ex);
+                progressCallback?.Report($"CSV export failed: {ex.Message}");
+            }
+
             progressCallback?.Report("Comparison completed successfully!");
             return result;
         }
@@ -147,6 +172,12 @@ public class ChatGptHttpService
     }
 
     #endregion
+
+    public string SaveChatGptResponseAsCsv(string chatResponseText, string fileNameWithoutExtension = "comparison")
+    {
+        var exporter = _responseExporter ?? new CsvChatGptResponseExporter(_logger);
+        return exporter.SaveAsCsv(chatResponseText, fileNameWithoutExtension, _outputDirectory);
+    }
 
     #region Private Helper Methods - Validation
 
@@ -459,6 +490,7 @@ EXIGENCES FINALES :
 
     #endregion
 }
+
 #region OpenAI API Models
 
 public class OpenAiChatRequest

--- a/Mira.Core/Services/CsvChatGptResponseExporter.cs
+++ b/Mira.Core/Services/CsvChatGptResponseExporter.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Mira.Core.Services;
+
+public class CsvChatGptResponseExporter : IChatGptResponseExporter
+{
+    private readonly ILoggerService _logger;
+
+    public CsvChatGptResponseExporter(ILoggerService logger)
+    {
+        _logger = logger;
+    }
+
+    public string SaveAsCsv(string chatResponseText, string fileNameWithoutExtension, string? outputDirectory)
+    {
+        var csv = ConvertChatGptMarkdownTablesToCsv(chatResponseText);
+        var dir = string.IsNullOrWhiteSpace(outputDirectory) ? Directory.GetCurrentDirectory() : outputDirectory!;
+        Directory.CreateDirectory(dir);
+        var filePath = Path.Combine(dir, $"{fileNameWithoutExtension}_{DateTime.Now:yyyyMMdd_HHmmss}.csv");
+        File.WriteAllText(filePath, csv, Encoding.UTF8);
+        _logger.LogInfo($"ChatGPT response saved as CSV: {filePath}");
+        return filePath;
+    }
+
+    private string ConvertChatGptMarkdownTablesToCsv(string chatResponseText)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Section,Client,Fournisseur,Statut");
+
+        using var reader = new StringReader(chatResponseText);
+        string? line;
+        string currentSection = string.Empty;
+        bool inTable = false;
+        bool headerSeen = false;
+
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var sectionMatch = Regex.Match(line, "^\\s*(\\d+)\\)\\s*(.+)$");
+            if (sectionMatch.Success)
+            {
+                currentSection = sectionMatch.Groups[2].Value.Trim();
+                inTable = false;
+                headerSeen = false;
+                continue;
+            }
+
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith("|"))
+            {
+                continue;
+            }
+
+            var parts = trimmed.Split('|').Select(p => p.Trim()).ToList();
+
+            var isSeparator = parts.Any(p => Regex.IsMatch(p, "^-{3,}$"));
+            if (isSeparator)
+            {
+                headerSeen = true;
+                inTable = true;
+                continue;
+            }
+
+            if (!headerSeen && parts.Count >= 4 && parts[1].IndexOf("Client", StringComparison.OrdinalIgnoreCase) >= 0 && parts[2].IndexOf("Fournisseur", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                continue;
+            }
+
+            if (inTable || headerSeen)
+            {
+                string client = parts.Count > 1 ? parts[1] : string.Empty;
+                string fournisseur = parts.Count > 2 ? parts[2] : string.Empty;
+                string statut = parts.Count > 3 ? parts[3] : string.Empty;
+
+                if (string.IsNullOrWhiteSpace(client) && string.IsNullOrWhiteSpace(fournisseur) && string.IsNullOrWhiteSpace(statut))
+                    continue;
+
+                sb.AppendLine($"{EscapeCsv(currentSection)},{EscapeCsv(client)},{EscapeCsv(fournisseur)},{EscapeCsv(statut)}");
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string EscapeCsv(string field)
+    {
+        if (field == null) return string.Empty;
+        var needsQuotes = field.Contains(',') || field.Contains('"') || field.Contains('\n') || field.StartsWith(" ") || field.EndsWith(" ");
+        var escaped = field.Replace("\"", "\"\"");
+        return needsQuotes ? $"\"{escaped}\"" : escaped;
+    }
+}

--- a/Mira.Core/Services/IChatGptResponseExporter.cs
+++ b/Mira.Core/Services/IChatGptResponseExporter.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Mira.Core.Services;
+
+public interface IChatGptResponseExporter
+{
+    /// <summary>
+    /// Convert the raw ChatGPT response text into CSV and save to disk.
+    /// Returns the full path to the saved file.
+    /// </summary>
+    string SaveAsCsv(string chatResponseText, string fileNameWithoutExtension, string? outputDirectory);
+}


### PR DESCRIPTION
Introduces an IChatGptResponseExporter interface and a default CsvChatGptResponseExporter implementation to modularize and automate exporting ChatGPT markdown table responses to CSV files. ChatGptHttpService now supports pluggable exporters, automatic CSV export after comparisons, and a public method for manual export. This improves testability, customization, and record-keeping of comparison results.