### PR TITLE
Add tabbed CSV comparison results viewer to main form

### DIFF
--- a/Mira.Core/Services/ChatGptHttpService.cs
+++ b/Mira.Core/Services/ChatGptHttpService.cs
@@ -81,11 +81,7 @@ public class ChatGptHttpService
     /// <summary>
     /// Compares two PDFs by converting them to images and sending via HTTP
     /// </summary>
-    public async Task<string> ComparePdfDocumentsAsync(
-   string clientPdfPath,
-        string supplierPdfPath,
-    IProgress<string>? progressCallback = null,
-        CancellationToken cancellationToken = default)
+    public async Task<string> ComparePdfDocumentsAsync(string clientPdfPath,string supplierPdfPath,IProgress<string>? progressCallback = null,CancellationToken cancellationToken = default)
     {
         _logger.LogInfo($"=== HTTP COMPARISON: {clientPdfPath} vs {supplierPdfPath} ===");
         progressCallback?.Report("Starting HTTP-based PDF comparison...");
@@ -118,11 +114,7 @@ public class ChatGptHttpService
     /// <summary>
     /// Compares pre-converted images via HTTP (main comparison method)
     /// </summary>
-    public async Task<string> ComparePdfDocumentsViaHttpAsync(
- List<byte[]> clientImages,
-        List<byte[]> supplierImages,
-        IProgress<string>? progressCallback = null,
-        CancellationToken cancellationToken = default)
+    public async Task<string> ComparePdfDocumentsViaHttpAsync(List<byte[]> clientImages,List<byte[]> supplierImages,IProgress<string>? progressCallback = null,CancellationToken cancellationToken = default)
     {
         _logger.LogInfo($"=== HTTP IMAGE COMPARISON: {clientImages.Count} client + {supplierImages.Count} supplier pages ===");
 

--- a/Mira.UI/CsvUiParser.cs
+++ b/Mira.UI/CsvUiParser.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Mira.UI;
+
+public static class CsvUiParser
+{
+    // Parses the CSV produced by the exporter into sections mapping to rows [Client,Fournisseur,Statut]
+    public static Dictionary<string, List<string[]>> ParseCsvToSections(string csvPath)
+    {
+        if (string.IsNullOrWhiteSpace(csvPath)) throw new ArgumentNullException(nameof(csvPath));
+        if (!File.Exists(csvPath)) throw new FileNotFoundException("CSV file not found", csvPath);
+
+        var lines = File.ReadAllLines(csvPath, Encoding.UTF8);
+        if (lines.Length <= 1) return new Dictionary<string, List<string[]>>();
+
+        var dataBySection = new Dictionary<string, List<string[]>>();
+
+        for (int i = 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var fields = ParseCsvLine(line);
+            if (fields.Length < 4) continue;
+            var section = fields[0];
+            if (!dataBySection.TryGetValue(section, out var list))
+            {
+                list = new List<string[]>();
+                dataBySection[section] = list;
+            }
+            list.Add(new[] { fields[1], fields[2], fields[3] });
+        }
+
+        return dataBySection;
+    }
+
+    // Simple CSV parser handling quoted fields and escaped quotes
+    private static string[] ParseCsvLine(string line)
+    {
+        var fields = new List<string>();
+        var sb = new StringBuilder();
+        bool inQuotes = false;
+
+        for (int i = 0; i < line.Length; i++)
+        {
+            char c = line[i];
+            if (c == '"')
+            {
+                if (inQuotes && i + 1 < line.Length && line[i + 1] == '"')
+                {
+                    sb.Append('"');
+                    i++; // skip escaped quote
+                }
+                else
+                {
+                    inQuotes = !inQuotes;
+                }
+            }
+            else if (c == ',' && !inQuotes)
+            {
+                fields.Add(sb.ToString());
+                sb.Clear();
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        fields.Add(sb.ToString());
+        return fields.ToArray();
+    }
+}

--- a/Mira.UI/FHome.Designer.cs
+++ b/Mira.UI/FHome.Designer.cs
@@ -67,6 +67,7 @@ partial class FHome
         clientPlanStatusLabel = new Label();
         statusStrip = new StatusStrip();
         statusStripLabel = new ToolStripStatusLabel();
+        comparisonTabControl = new TabControl();
         mainMenuStrip.SuspendLayout();
         generalInfoGroupBox.SuspendLayout();
         comparisonContainerGroupBox.SuspendLayout();
@@ -81,7 +82,7 @@ partial class FHome
         mainMenuStrip.Items.AddRange(new ToolStripItem[] { comparisonToolStripMenuItem, reviewToolStripMenuItem, exportToolStripMenuItem });
         mainMenuStrip.Location = new Point(0, 0);
         mainMenuStrip.Name = "mainMenuStrip";
-        mainMenuStrip.Size = new Size(800, 24);
+        mainMenuStrip.Size = new Size(1461, 24);
         mainMenuStrip.TabIndex = 0;
         mainMenuStrip.Text = "mainMenuStrip";
         // 
@@ -95,38 +96,39 @@ partial class FHome
         // newComparisonToolStripMenuItem
         // 
         newComparisonToolStripMenuItem.Name = "newComparisonToolStripMenuItem";
-        newComparisonToolStripMenuItem.Size = new Size(180, 22);
+        newComparisonToolStripMenuItem.Size = new Size(158, 22);
         newComparisonToolStripMenuItem.Text = "Nouveau";
         newComparisonToolStripMenuItem.Click += newComparisonToolStripMenuItem_Click;
         // 
         // openComparisonToolStripMenuItem
         // 
         openComparisonToolStripMenuItem.Name = "openComparisonToolStripMenuItem";
-        openComparisonToolStripMenuItem.Size = new Size(180, 22);
+        openComparisonToolStripMenuItem.Size = new Size(158, 22);
         openComparisonToolStripMenuItem.Text = "Open";
+        openComparisonToolStripMenuItem.Click += openComparisonToolStripMenuItem_Click;
         // 
         // saveComparisonToolStripMenuItem
         // 
         saveComparisonToolStripMenuItem.Name = "saveComparisonToolStripMenuItem";
-        saveComparisonToolStripMenuItem.Size = new Size(180, 22);
+        saveComparisonToolStripMenuItem.Size = new Size(158, 22);
         saveComparisonToolStripMenuItem.Text = "Enregistrer";
         // 
         // saveAsComparisonToolStripMenuItem
         // 
         saveAsComparisonToolStripMenuItem.Name = "saveAsComparisonToolStripMenuItem";
-        saveAsComparisonToolStripMenuItem.Size = new Size(180, 22);
+        saveAsComparisonToolStripMenuItem.Size = new Size(158, 22);
         saveAsComparisonToolStripMenuItem.Text = "Enregistrer Sous";
         // 
         // deleteComparisonToolStripMenuItem
         // 
         deleteComparisonToolStripMenuItem.Name = "deleteComparisonToolStripMenuItem";
-        deleteComparisonToolStripMenuItem.Size = new Size(180, 22);
+        deleteComparisonToolStripMenuItem.Size = new Size(158, 22);
         deleteComparisonToolStripMenuItem.Text = "Supprimer";
         // 
         // exitApplicationToolStripMenuItem
         // 
         exitApplicationToolStripMenuItem.Name = "exitApplicationToolStripMenuItem";
-        exitApplicationToolStripMenuItem.Size = new Size(180, 22);
+        exitApplicationToolStripMenuItem.Size = new Size(158, 22);
         exitApplicationToolStripMenuItem.Text = "Quitter";
         // 
         // reviewToolStripMenuItem
@@ -161,7 +163,7 @@ partial class FHome
         // 
         exportToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { exportExcelFormatToolStripMenuItem, exportWordFormatToolStripMenuItem, exportCsvFormatToolStripMenuItem });
         exportToolStripMenuItem.Name = "exportToolStripMenuItem";
-        exportToolStripMenuItem.Size = new Size(59, 20);
+        exportToolStripMenuItem.Size = new Size(58, 20);
         exportToolStripMenuItem.Text = "Exporte";
         // 
         // exportExcelFormatToolStripMenuItem
@@ -315,7 +317,7 @@ partial class FHome
         comparisonContainerGroupBox.Controls.Add(generalInfoGroupBox);
         comparisonContainerGroupBox.Location = new Point(12, 41);
         comparisonContainerGroupBox.Name = "comparisonContainerGroupBox";
-        comparisonContainerGroupBox.Size = new Size(776, 397);
+        comparisonContainerGroupBox.Size = new Size(776, 186);
         comparisonContainerGroupBox.TabIndex = 2;
         comparisonContainerGroupBox.TabStop = false;
         comparisonContainerGroupBox.Text = "Comparison COMP0001";
@@ -397,29 +399,40 @@ partial class FHome
         // statusStrip
         // 
         statusStrip.Items.AddRange(new ToolStripItem[] { statusStripLabel });
-        statusStrip.Location = new Point(0, 428);
+        statusStrip.Location = new Point(0, 969);
         statusStrip.Name = "statusStrip";
-        statusStrip.Size = new Size(800, 22);
+        statusStrip.Size = new Size(1461, 22);
         statusStrip.TabIndex = 3;
         statusStrip.Text = "statusStrip";
         // 
         // statusStripLabel
         // 
         statusStripLabel.Name = "statusStripLabel";
-        statusStripLabel.Size = new Size(118, 17);
+        statusStripLabel.Size = new Size(123, 17);
         statusStripLabel.Text = "ChatGPT: Initializing...";
+        // 
+        // comparisonTabControl
+        // 
+        comparisonTabControl.Dock = DockStyle.Bottom;
+        comparisonTabControl.Location = new Point(0, 249);
+        comparisonTabControl.Name = "comparisonTabControl";
+        comparisonTabControl.SelectedIndex = 0;
+        comparisonTabControl.Size = new Size(1461, 720);
+        comparisonTabControl.TabIndex = 4;
         // 
         // FHome
         // 
         AutoScaleDimensions = new SizeF(7F, 15F);
         AutoScaleMode = AutoScaleMode.Font;
-        ClientSize = new Size(800, 450);
+        ClientSize = new Size(1461, 991);
+        Controls.Add(comparisonTabControl);
         Controls.Add(statusStrip);
         Controls.Add(comparisonContainerGroupBox);
         Controls.Add(mainMenuStrip);
         MainMenuStrip = mainMenuStrip;
         Name = "FHome";
         Text = "Mira- Revue Technique des Plans";
+        WindowState = FormWindowState.Maximized;
         mainMenuStrip.ResumeLayout(false);
         mainMenuStrip.PerformLayout();
         generalInfoGroupBox.ResumeLayout(false);
@@ -453,6 +466,7 @@ partial class FHome
     private ToolStripMenuItem exportExcelFormatToolStripMenuItem;
     private ToolStripMenuItem exportWordFormatToolStripMenuItem;
     private ToolStripMenuItem exportCsvFormatToolStripMenuItem;
+    private TabControl comparisonTabControl;
     private GroupBox generalInfoGroupBox;
     private TextBox responsiblePersonTextBox;
     private Label responsiblePersonLabel;

--- a/Mira.UI/FHome.cs
+++ b/Mira.UI/FHome.cs
@@ -2,6 +2,10 @@ using Mira.Core;
 using Mira.Core.DTO;
 using Mira.Core.Services;
 using System.Text.Json;
+using System.Text;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Mira.UI;
 
@@ -274,6 +278,29 @@ public partial class FHome : Form
         HandleImportFile(Enums.ReportType.EMP);
     }
 
+    private void openComparisonToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        _loggerService.LogInfo("User clicked Open Comparison menu item");
+
+        using var ofd = new OpenFileDialog();
+        ofd.Title = "Open comparison CSV";
+        ofd.Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*";
+        ofd.InitialDirectory = AppDomain.CurrentDomain.BaseDirectory;
+        if (ofd.ShowDialog() == DialogResult.OK)
+        {
+            try
+            {
+                LoadCsvIntoTabs(ofd.FileName);
+                _loggerService.LogInfo($"Loaded comparison CSV: {ofd.FileName}");
+            }
+            catch (Exception ex)
+            {
+                _loggerService.LogError("Failed to load selected comparison CSV", ex);
+                MessageBox.Show($"Failed to load CSV: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+    }
+
     /// <summary>
     /// Opens the specified plan file
     /// </summary>
@@ -420,38 +447,51 @@ MessageBox.Show(
         {
      _loggerService.LogInfo("Starting comparison analysis");
 
-          statusStripLabel.Text = "ChatGPT: Initializing comparison...";
-            statusStripLabel.ForeColor = Color.Orange;
+           statusStripLabel.Text = "ChatGPT: Initializing comparison...";
+             statusStripLabel.ForeColor = Color.Orange;
 
-     // Get full file paths
-         string clientFilePath = Path.Combine(comparisonDto.BaseReportDirectory, comparisonDto.ClientPlantPath);
-            string empFilePath = Path.Combine(comparisonDto.BaseReportDirectory, comparisonDto.EmpPlanPath);
+      // Get full file paths
+          string clientFilePath = Path.Combine(comparisonDto.BaseReportDirectory, comparisonDto.ClientPlantPath);
+             string empFilePath = Path.Combine(comparisonDto.BaseReportDirectory, comparisonDto.EmpPlanPath);
 
-_loggerService.LogInfo($"Client path: {clientFilePath}");
-     _loggerService.LogInfo($"EMP path: {empFilePath}");
+ _loggerService.LogInfo($"Client path: {clientFilePath}");
+      _loggerService.LogInfo($"EMP path: {empFilePath}");
 
-        // Compare both documents WITH PROGRESS REPORTING
-string comparisonResult = await _chatGptService.ComparePdfDocumentsAsync(
-       clientFilePath, 
-                empFilePath, 
-progress);  // Pass progress callback
+         // Compare both documents WITH PROGRESS REPORTING
+ string comparisonResult = await _chatGptService.ComparePdfDocumentsAsync(
+        clientFilePath, 
+                 empFilePath, 
+ progress);  // Pass progress callback
 
- // Log the comparison result
-          _loggerService.LogInfo("Logging comparison result");
-        _loggerService.LogChatGptResponse($"Comparison_{comparisonDto.Id}", comparisonResult);
+  // Log the comparison result
+           _loggerService.LogInfo("Logging comparison result");
+         _loggerService.LogChatGptResponse($"Comparison_{comparisonDto.Id}", comparisonResult);
+
+            // Save comparison result as CSV using exporter and load into UI tabs
+            try
+            {
+                var exporter = new CsvChatGptResponseExporter(_loggerService);
+                var csvPath = exporter.SaveAsCsv(comparisonResult, $"Comparison_{comparisonDto.Id}", comparisonDto.BaseReportDirectory);
+                _loggerService.LogInfo($"Saved comparison CSV to: {csvPath}");
+                LoadCsvIntoTabs(csvPath);
+            }
+            catch (Exception ex)
+            {
+                _loggerService.LogError("Failed to save/load CSV for comparison result", ex);
+            }
 
             statusStripLabel.Text = "ChatGPT: Comparison completed successfully ✓";
             statusStripLabel.ForeColor = Color.Green;
 
- _loggerService.LogInfo("Comparison analysis completed successfully");
+  _loggerService.LogInfo("Comparison analysis completed successfully");
 
-            MessageBox.Show(
-     $"Comparison completed successfully!\n\nResponse length: {comparisonResult.Length} characters\n\nCheck the logs for detailed results.",
-             "Comparison Complete",
-                MessageBoxButtons.OK,
-   MessageBoxIcon.Information
-     );
-     }
+             MessageBox.Show(
+      $"Comparison completed successfully!\n\nResponse length: {comparisonResult.Length} characters\n\nCheck the logs for detailed results.",
+              "Comparison Complete",
+                 MessageBoxButtons.OK,
+    MessageBoxIcon.Information
+      );
+      }
     catch (TimeoutException ex)
         {
             _loggerService.LogError("Comparison timed out", ex);
@@ -525,5 +565,129 @@ progress);  // Pass progress callback
             _loggerService.LogError("EMP plan ChatGPT PDF analysis failed", ex);
             throw;
         }
+    }
+
+    private void LoadCsvIntoTabs(string csvPath)
+    {
+        try
+        {
+            if (!File.Exists(csvPath))
+            {
+                _loggerService.LogError($"CSV file not found: {csvPath}");
+                return;
+            }
+
+            // Read all lines and parse CSV rows
+            var lines = File.ReadAllLines(csvPath, Encoding.UTF8);
+            if (lines.Length <= 1)
+            {
+                _loggerService.LogWarning("CSV file contains no data");
+                return;
+            }
+
+            // First line is header: Section,Client,Fournisseur,Statut
+            var dataBySection = new Dictionary<string, List<string[]>>();
+
+            for (int i = 1; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                // Simple CSV split that handles quoted fields
+                var fields = ParseCsvLine(line);
+                if (fields.Length < 4) continue;
+                var section = fields[0];
+                if (!dataBySection.TryGetValue(section, out var list))
+                {
+                    list = new List<string[]>();
+                    dataBySection[section] = list;
+                }
+                list.Add(new[] { fields[1], fields[2], fields[3] });
+            }
+
+            // Clear existing tabs and create a TabControl dynamically if not present
+            TabControl? tabControl = this.Controls.OfType<TabControl>().FirstOrDefault(t => t.Name == "comparisonTabControl");
+            if (tabControl == null)
+            {
+                tabControl = new TabControl();
+                tabControl.Name = "comparisonTabControl";
+                tabControl.Dock = DockStyle.Top;
+                tabControl.Height = 250;
+                this.Controls.Add(tabControl);
+                // Place it above the comparison container
+                tabControl.BringToFront();
+            }
+
+            tabControl.TabPages.Clear();
+
+            foreach (var kv in dataBySection)
+             {
+                 var tab = new TabPage(kv.Key);
+                 var grid = new DataGridView();
+                 grid.Dock = DockStyle.Fill;
+                 grid.ReadOnly = true;
+                 grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
+                 grid.Columns.Add("Client", "Client");
+                 grid.Columns.Add("Fournisseur", "Fournisseur");
+                 grid.Columns.Add("Statut", "Statut");
+ 
+                 foreach (var row in kv.Value)
+                 {
+                     var idx = grid.Rows.Add(row[0], row[1], row[2]);
+                     var dgRow = grid.Rows[idx];
+                     if (string.Equals(row[2]?.Trim(), "Conforme", StringComparison.OrdinalIgnoreCase))
+                     {
+                         dgRow.DefaultCellStyle.BackColor = Color.LightGreen;
+                     }
+                     else
+                     {
+                         dgRow.DefaultCellStyle.BackColor = Color.LightCoral;
+                     }
+                 }
+ 
+                 tab.Controls.Add(grid);
+                 tabControl.TabPages.Add(tab);
+             }
+
+            _loggerService.LogInfo($"Loaded CSV into {dataBySection.Count} tabs");
+        }
+        catch (Exception ex)
+        {
+            _loggerService.LogError("Failed to load CSV into tabs", ex);
+        }
+    }
+
+    private string[] ParseCsvLine(string line)
+    {
+        var fields = new List<string>();
+        var sb = new StringBuilder();
+        bool inQuotes = false;
+
+        for (int i = 0; i < line.Length; i++)
+        {
+            char c = line[i];
+            if (c == '"')
+            {
+                if (inQuotes && i + 1 < line.Length && line[i + 1] == '"')
+                {
+                    sb.Append('"');
+                    i++; // skip escaped quote
+                }
+                else
+                {
+                    inQuotes = !inQuotes;
+                }
+            }
+            else if (c == ',' && !inQuotes)
+            {
+                fields.Add(sb.ToString());
+                sb.Clear();
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        fields.Add(sb.ToString());
+        return fields.ToArray();
     }
 }

--- a/Mira.UI/FHome.resx
+++ b/Mira.UI/FHome.resx
@@ -118,6 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="mainMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>126, 17</value>
+  </metadata>
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
Introduce a TabControl to FHome for displaying comparison results loaded from CSV files, grouped by section. Add CsvUiParser for robust CSV parsing. Implement "Open" menu action to load CSVs into tabs, each showing a DataGridView with color-coded statuses. Adjust form size and layout to accommodate the new UI. Exported comparison results are now immediately viewable in the tabbed interface. Minor UI and event handler updates included.